### PR TITLE
Update Wrangler configuration to JSON

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,5 @@
+{
+  "name": "awwbot",
+  "main": "./src/server.js",
+  "compatibility_date": "2023-05-18"
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,8 +1,0 @@
-name = "awwbot"
-main = "./src/server.js"
-compatibility_date="2023-05-18"
-
-# [secrets]
-# DISCORD_TOKEN
-# DISCORD_PUBLIC_KEY
-# DISCORD_APPLICATION_ID


### PR DESCRIPTION
Updates the Wrangler configuration from TOML to JSON or specifically, JSON with comments (`.jsonc`). Cloudflare recommends `wrangler.jsonc` over `wrangler.toml` in their [official documentation](https://developers.cloudflare.com/workers/wrangler/configuration/). This PR just updates to the configuration to use the recommended file format from Cloudflare.

From Cloudflare's documentation:
> As of Wrangler v3.91.0 Wrangler supports both JSON (`wrangler.json` or `wrangler.jsonc`) and TOML (`wrangler.toml`) for its configuration file. Prior to that version, only `wrangler.toml` was supported.
> 
> **Cloudflare recommends using `wrangler.jsonc` for new projects.**
> 
> The format of Wrangler's configuration file is exactly the same across both languages, only the syntax differs.
> 
> You can use one of the many available online converters to easily switch between the two.
> 
> Throughout this page and the rest of Cloudflare's documentation, configuration snippets are provided as both JSON and TOML.
>
> https://developers.cloudflare.com/workers/wrangler/configuration/

### Notes

There is no `secrets` key equivalent anymore in the Wrangler configuration. The closest would be the `vars` [non-inheritable key](https://developers.cloudflare.com/workers/wrangler/configuration/#non-inheritable-keys) but those are only for environment variables and not secrets such as your Discord bot token. It is easy to accidentally commit your secrets because there's no way to `.gitignore` just the `vars` key in a JSON. I've removed the keys that include secrets, but they can be added back into using this:

```jsonc
{
//   "vars": {
//     "DISCORD_TOKEN": "..",
//     "DISCORD_PUBLIC_KEY": "..",
//     "DISCORD_APPLICATION_ID": ".."
//   }
}
```