### PR TITLE
fix: use post.data.is_gallery and handle empty posts array

### DIFF
--- a/src/reddit.js
+++ b/src/reddit.js
@@ -25,7 +25,7 @@ export async function getCuteUrl() {
   const data = await response.json();
   const posts = data.data.children
     .map((post) => {
-      if (post.is_gallery) {
+      if (post.data?.is_gallery) {
         return '';
       }
       return (
@@ -35,9 +35,11 @@ export async function getCuteUrl() {
       );
     })
     .filter((post) => !!post);
+  if (!posts.length) {
+    return 'https://i.imgur.com/removed.png';
+  }
   const randomIndex = Math.floor(Math.random() * posts.length);
-  const randomPost = posts[randomIndex];
-  return randomPost;
+  return posts[randomIndex];
 }
 
 export const redditUrl = 'https://www.reddit.com/r/aww/hot.json';


### PR DESCRIPTION
## Problem

1. **`post.is_gallery` is always `undefined`** — the gallery flag lives under `post.data.is_gallery`, not `post.is_gallery`. This means gallery posts (which don't have a direct image URL) are never filtered out, potentially returning broken links.

2. **No fallback when posts array is empty** — if all posts are filtered out (e.g. all gallery posts), `posts[Math.floor(Math.random() * 0)]` returns `undefined`, which gets sent as the bot's response.

## Fix

- Changed `post.is_gallery` → `post.data?.is_gallery`
- Added an early return with a fallback URL when no valid posts are found
- Simplified the return statement (removed unnecessary temp variable)