### PR TITLE
fix: multiple bug fixes across reddit, server, register, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Below is a basic overview of the project structure:
 │   ├── register.js           -> Sets up commands with the Discord API
 │   ├── server.js             -> Discord app logic and routing
 ├── test
-|   ├── test.js               -> Tests for app
+|   ├── server.test.js        -> Tests for app
 ├── wrangler.toml             -> Configuration for Cloudflare workers
 ├── package.json
 ├── README.md
-├── .eslintrc.json
+├── eslint.config.js
 ├── .prettierignore
 ├── .prettierrc.json
 └── .gitignore
@@ -111,7 +111,7 @@ This is the process we'll use for local testing and development. When you've pub
 
 ## Deploying app
 
-This repository is set up to automatically deploy to Cloudflare Workers when new changes land on the `main` branch. To deploy manually, run `npm run publish`, which uses the `wrangler publish` command under the hood. Publishing via a GitHub Action requires obtaining an [API Token and your Account ID from Cloudflare](https://developers.cloudflare.com/workers/wrangler/cli-wrangler/authentication/#generate-tokens). These are stored [as secrets in the GitHub repository](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository), making them available to GitHub Actions. The following configuration in `.github/workflows/ci.yaml` demonstrates how to tie it all together:
+This repository is set up to automatically deploy to Cloudflare Workers when new changes land on the `main` branch. To deploy manually, run `npm run publish`, which uses the `wrangler deploy` command under the hood. Publishing via a GitHub Action requires obtaining an [API Token and your Account ID from Cloudflare](https://developers.cloudflare.com/workers/wrangler/cli-wrangler/authentication/#generate-tokens). These are stored [as secrets in the GitHub repository](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository), making them available to GitHub Actions. The following configuration in `.github/workflows/ci.yaml` demonstrates how to tie it all together:
 
 ```yaml
 release:
@@ -119,8 +119,8 @@ release:
   runs-on: ubuntu-latest
   needs: [test, lint]
   steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: 18
     - run: npm install

--- a/src/reddit.js
+++ b/src/reddit.js
@@ -23,21 +23,40 @@ export async function getCuteUrl() {
     throw new Error(errorText);
   }
   const data = await response.json();
-  const posts = data.data.children
+  const posts = data?.data?.children;
+  if (!Array.isArray(posts)) {
+    throw new Error('Unexpected response structure from Reddit API');
+  }
+  const urls = posts
     .map((post) => {
-      if (post.is_gallery) {
-        return '';
-      }
+      const d = post?.data;
+      if (!d) return '';
+      // Skip gallery posts — they don't have a single direct media URL
+      if (d.is_gallery) return '';
+      // Skip NSFW posts
+      if (d.over_18) return '';
       return (
-        post.data?.media?.reddit_video?.fallback_url ||
-        post.data?.secure_media?.reddit_video?.fallback_url ||
-        post.data?.url
+        d.media?.reddit_video?.fallback_url ||
+        d.secure_media?.reddit_video?.fallback_url ||
+        d.url ||
+        ''
       );
     })
-    .filter((post) => !!post);
-  const randomIndex = Math.floor(Math.random() * posts.length);
-  const randomPost = posts[randomIndex];
-  return randomPost;
+    .filter((url) => {
+      if (!url) return false;
+      // Only allow URLs that look like images or videos
+      try {
+        const parsed = new URL(url);
+        return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+      } catch {
+        return false;
+      }
+    });
+  if (!urls.length) {
+    throw new Error('No valid posts found in the Reddit API response');
+  }
+  const randomIndex = Math.floor(Math.random() * urls.length);
+  return urls[randomIndex];
 }
 
 export const redditUrl = 'https://www.reddit.com/r/aww/hot.json';

--- a/src/register.js
+++ b/src/register.js
@@ -14,11 +14,13 @@ const token = process.env.DISCORD_TOKEN;
 const applicationId = process.env.DISCORD_APPLICATION_ID;
 
 if (!token) {
-  throw new Error('The DISCORD_TOKEN environment variable is required.');
+  throw new Error(
+    'The DISCORD_TOKEN environment variable is required. Make sure to set it in your .dev.vars file.',
+  );
 }
 if (!applicationId) {
   throw new Error(
-    'The DISCORD_APPLICATION_ID environment variable is required.',
+    'The DISCORD_APPLICATION_ID environment variable is required. Make sure to set it in your .dev.vars file.',
   );
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -4,13 +4,13 @@
 
 import { AutoRouter } from 'itty-router';
 import {
+  InteractionResponseFlags,
   InteractionResponseType,
   InteractionType,
   verifyKey,
 } from 'discord-interactions';
 import { AWW_COMMAND, INVITE_COMMAND } from './commands.js';
 import { getCuteUrl } from './reddit.js';
-import { InteractionResponseFlags } from 'discord-interactions';
 
 class JsonResponse extends Response {
   constructor(body, init) {
@@ -59,13 +59,24 @@ router.post('/', async (request, env) => {
     // Most user commands will come as `APPLICATION_COMMAND`.
     switch (interaction.data.name.toLowerCase()) {
       case AWW_COMMAND.name.toLowerCase(): {
-        const cuteUrl = await getCuteUrl();
-        return new JsonResponse({
-          type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
-          data: {
-            content: cuteUrl,
-          },
-        });
+        try {
+          const cuteUrl = await getCuteUrl();
+          return new JsonResponse({
+            type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+            data: {
+              content: cuteUrl,
+            },
+          });
+        } catch (err) {
+          console.error('Error fetching cute URL:', err);
+          return new JsonResponse({
+            type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+            data: {
+              content: 'Could not fetch a cute image right now. Try again!',
+              flags: InteractionResponseFlags.EPHEMERAL,
+            },
+          });
+        }
       }
       case INVITE_COMMAND.name.toLowerCase(): {
         const applicationId = env.DISCORD_APPLICATION_ID;
@@ -79,12 +90,15 @@ router.post('/', async (request, env) => {
         });
       }
       default:
-        return new JsonResponse({ error: 'Unknown Type' }, { status: 400 });
+        return new JsonResponse({ error: 'Unknown command' }, { status: 400 });
     }
   }
 
-  console.error('Unknown Type');
-  return new JsonResponse({ error: 'Unknown Type' }, { status: 400 });
+  console.error('Unknown interaction type:', interaction.type);
+  return new JsonResponse(
+    { error: 'Unknown interaction type' },
+    { status: 400 },
+  );
 });
 router.all('*', () => new Response('Not Found.', { status: 404 }));
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -87,7 +87,19 @@ describe('Server', () => {
         .resolves({
           status: 200,
           ok: true,
-          json: sinon.fake.resolves({ data: { children: [] } }),
+          json: sinon.fake.resolves({
+            data: {
+              children: [
+                {
+                  data: {
+                    url: 'https://i.redd.it/cute-cat.jpg',
+                    is_gallery: false,
+                    over_18: false,
+                  },
+                },
+              ],
+            },
+          }),
         });
 
       const response = await server.fetch(request, env);
@@ -152,7 +164,7 @@ describe('Server', () => {
       const response = await server.fetch(request, {});
       const body = await response.json();
       expect(response.status).to.equal(400);
-      expect(body.error).to.equal('Unknown Type');
+      expect(body.error).to.equal('Unknown command');
     });
   });
 


### PR DESCRIPTION
## Summary

A comprehensive set of bug fixes and improvements found while reviewing the codebase.

## Bug Fixes

### `src/reddit.js`
- **`post.is_gallery` → `post.data.is_gallery`**: The gallery flag lives under `post.data`, not `post` directly. Gallery posts were never being filtered out, which could return broken URLs to users.
- **Empty posts array crash**: When all posts are filtered out (e.g., all gallery or NSFW posts), `posts[Math.floor(Math.random() * 0)]` returns `undefined`. Now throws a descriptive error instead.
- **NSFW filtering**: Added `over_18` check to prevent NSFW content from being served through the bot.
- **Response validation**: Added a guard for unexpected Reddit API response structures.
- **URL validation**: Validate that returned URLs have a valid protocol before sending them to users.

### `src/server.js`
- **Duplicate import**: `InteractionResponseFlags` was imported separately on line 12 when it could be included in the existing import block from `discord-interactions`.
- **Unhandled `getCuteUrl` errors**: If the Reddit API call fails, the bot would crash with an unhandled promise rejection. Now catches errors and returns a friendly ephemeral message.
- **Ambiguous error messages**: Both unknown commands and unknown interaction types returned `"Unknown Type"`. Now returns `"Unknown command"` and `"Unknown interaction type"` respectively for easier debugging.

### `src/register.js`
- **Unhelpful error messages**: Error messages for missing `DISCORD_TOKEN` and `DISCORD_APPLICATION_ID` now mention the `.dev.vars` file where they should be configured.

### `README.md`
- **Outdated command**: `wrangler publish` was deprecated in favor of `wrangler deploy`. The `package.json` script already uses `deploy`, but the README still referenced the old command name.
- **Stale project structure**: Updated `test.js` → `server.test.js` and `.eslintrc.json` → `eslint.config.js` to match the current repository structure.
- **Outdated GitHub Actions**: Updated `actions/checkout` and `actions/setup-node` from `v3` to `v4`.

### `test/server.test.js`
- **Empty mock data**: The AWW command test was mocking an empty `children` array, which would now (correctly) trigger an error. Updated to include realistic post data.
- **Updated assertion**: Aligned the unknown command test assertion with the improved error message.

## Testing

All 6 tests pass, lint is clean:

```
  Server
    GET /
      ✔ should return a greeting message with the Discord application ID
    POST /
      ✔ should handle a PING interaction
      ✔ should handle an AWW command interaction
      ✔ should handle an invite command interaction
      ✔ should handle an unknown command interaction
    All other routes
      ✔ should return a "Not Found" response

  6 passing
```